### PR TITLE
Fix: nonNegativeInteger values for beginIndex and endIndex

### DIFF
--- a/java-maven/core/jena/src/main/java/org/nlp2rdf/core/Text2RDF.java
+++ b/java-maven/core/jena/src/main/java/org/nlp2rdf/core/Text2RDF.java
@@ -21,8 +21,11 @@
 
 package org.nlp2rdf.core;
 
+import com.hp.hpl.jena.datatypes.RDFDatatype;
+import com.hp.hpl.jena.graph.NodeFactory;
 import com.hp.hpl.jena.ontology.Individual;
 import com.hp.hpl.jena.ontology.OntModel;
+import com.hp.hpl.jena.vocabulary.XSD;
 import com.jamonapi.Monitor;
 import com.jamonapi.MonitorFactory;
 import org.nlp2rdf.core.urischemes.URIScheme;
@@ -48,8 +51,7 @@ public class Text2RDF {
         Individual context = model.createIndividual(uri, model.createClass(uriScheme.getOWLClassURI()));
         context.addOntClass(NIFOntClasses.Context.getOntClass(model));
         context.addLiteral(NIFDatatypeProperties.isString.getDatatypeProperty(model), model.createLiteral(contextString));
-        context.addProperty(NIFDatatypeProperties.beginIndex.getDatatypeProperty(model), span.getStart() + "");
-        context.addProperty(NIFDatatypeProperties.endIndex.getDatatypeProperty(model), span.getEnd() + "");
+        addStartEndIndices(context, span, model);
         return context;
     }
 
@@ -59,12 +61,17 @@ public class Text2RDF {
         String uri = uriScheme.generate(prefix, contextString, new Span[]{span});
         Individual string = model.createIndividual(uri, model.createClass(uriScheme.getOWLClassURI()));
         string.addLiteral(NIFDatatypeProperties.anchorOf.getDatatypeProperty(model), model.createLiteral(span.getCoveredText(contextString).toString()));
-        string.addProperty(NIFDatatypeProperties.beginIndex.getDatatypeProperty(model), span.getStart() + "");
-        string.addProperty(NIFDatatypeProperties.endIndex.getDatatypeProperty(model), span.getEnd() + "");
         string.addProperty(NIFObjectProperties.referenceContext.getObjectProperty(model), context);
+        addStartEndIndices(string, span, model);
         return string;
     }
 
+    private void addStartEndIndices(Individual individual, Span span, OntModel model) {
+      RDFDatatype nonNegInt = NodeFactory.getType(XSD.nonNegativeInteger.getURI());
+
+      individual.addProperty(NIFDatatypeProperties.beginIndex.getDatatypeProperty(model), span.getStart() + "", nonNegInt);
+      individual.addProperty(NIFDatatypeProperties.endIndex.getDatatypeProperty(model), span.getEnd() + "", nonNegInt);
+    }
 
     public void generateNIFModel(String prefix, Individual context, URIScheme uriScheme, OntModel model, TreeMap<Span, List<Span>> tokenizedText) {
         assert tokenizedText != null && context != null && uriScheme != null && prefix != null;
@@ -128,65 +135,4 @@ public class Text2RDF {
             mon.stop();
         }
     }
-
-    /*public void expand(String prefix, URIScheme uriScheme, final OntModel model) {
-
-        final DatatypeProperty beginIndex = NIFDatatypeProperties.beginIndex.getDatatypeProperty(model);
-      //  final ObjectProperty beginIndex = NIFDatatypeProperties.beginIndex.getDatatypeProperty(model);
-        Monitor mon = MonitorFactory.getTimeMonitor("addNextAndPreviousProperties").start();
-
-        long previous = model.size();
-        ExtendedIterator<Individual> itw = model.listIndividuals(NIFOntClasses.Word.getOntClass(model));
-
-        SortedSet<Individual> words = new TreeSet<Individual>(new Comparator<Individual>() {
-            @Override
-            public int compare(Individual individual, Individual individual1) {
-                int a = individual.getPropertyValue(beginIndex).asLiteral().getInt();
-                int b = individual1.getPropertyValue(beginIndex).asLiteral().getInt();
-                return a - b;
-            }
-        });
-        words.addAll(itw.toSet());
-
-        Individual previousSentence = null;
-        for (Individual word : words) {
-           // Individual currentSentence = word.getPropertyValue()
-
-
-            System.out.println(word);
-        }
-
-        System.exit(0);
-
-        /**ExtendedIterator<Individual> its = model.listIndividuals(NIFOntClasses.Sentence.getOntClass(model));
-         for (Individual sentence = null; its.hasNext(); sentence = its.next()) {
-
-
-         }
-
-         List<Sentence> sentences = Sentence.list(model);
-         Collections.sort(sentences, new URIComparator(prefix, text, uriGenerator));
-         for (int x = 0; x < sentences.size(); x++) {
-         Sentence sentence = sentences.get(x);
-         List<Word> words = sentence.listWord();
-         Collections.sort(words, new URIComparator(prefix, text, uriGenerator));
-         if (x < sentences.size() - 1) {
-         //not the last one
-         sentence.setNextSentence(sentences.get(x + 1));
-         }
-
-         for (int y = 0; y < words.size(); y++) {
-         Word word = words.get(y);
-         //not the last one
-         if (y < words.size() - 1) {
-         word.setNextWord(words.get(y + 1));
-         }
-         }
-         }
-
-        mon.stop();
-        log.debug("Finished addition of next/previous properties " + (model.size() - previous) + " triples added, " + mon.getLastValue() + " ms.)");
-    }  */
-
-
 }

--- a/java-maven/implementation/conll/src/main/java/org/nlp2rdf/implementation/conll/ConLLToNIF.java
+++ b/java-maven/implementation/conll/src/main/java/org/nlp2rdf/implementation/conll/ConLLToNIF.java
@@ -12,6 +12,9 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.hp.hpl.jena.datatypes.RDFDatatype;
+import com.hp.hpl.jena.graph.NodeFactory;
+import com.hp.hpl.jena.vocabulary.XSD;
 import org.apache.commons.collections.map.MultiValueMap;
 import org.nlp2rdf.core.Format;
 import org.nlp2rdf.core.NIFParameters;
@@ -59,7 +62,8 @@ public class ConLLToNIF {
 		contextResource = outputModel.createIndividual(uri, outputModel.createClass(NIFOntClasses.RFC5147String.getUri()));
 		contextResource.addOntClass(NIFOntClasses.Context.getOntClass(outputModel));
 		contextResource.addOntClass(NIFOntClasses.String.getOntClass(outputModel));
-		contextResource.addProperty(NIFDatatypeProperties.beginIndex.getDatatypeProperty(outputModel), "0");
+    RDFDatatype nonNegInt = NodeFactory.getType(XSD.nonNegativeInteger.getURI());
+    contextResource.addProperty(NIFDatatypeProperties.beginIndex.getDatatypeProperty(outputModel), "0", nonNegInt);
 		
 		if(!nifParameters.getOptions().has("informat")) {
 			log.warn("informat parameter empty, please choose informat=file or informat=text");
@@ -190,8 +194,9 @@ public class ConLLToNIF {
 			Individual wordResource = outputModel.createIndividual(uri, outputModel.createClass(NIFOntClasses.RFC5147String.getUri()));
 			wordResource.addOntClass(NIFOntClasses.Word.getOntClass(outputModel));
 			wordResource.addOntClass(NIFOntClasses.String.getOntClass(outputModel));
-			wordResource.addProperty(NIFDatatypeProperties.beginIndex.getDatatypeProperty(outputModel), word.getStart()+"");
-			wordResource.addProperty(NIFDatatypeProperties.endIndex.getDatatypeProperty(outputModel), word.getEnd()+"");
+      RDFDatatype nonNegInt = NodeFactory.getType(XSD.nonNegativeInteger.getURI());
+      wordResource.addProperty(NIFDatatypeProperties.beginIndex.getDatatypeProperty(outputModel), word.getStart()+"", nonNegInt);
+			wordResource.addProperty(NIFDatatypeProperties.endIndex.getDatatypeProperty(outputModel), word.getEnd()+"", nonNegInt);
 			wordResource.addLiteral(NIFDatatypeProperties.anchorOf.getDatatypeProperty(outputModel), outputModel.createLiteral(word.getWordString()));
 			wordResource.addProperty(NIFDatatypeProperties.posTag.getDatatypeProperty(outputModel), word.getPos());
 			
@@ -240,8 +245,9 @@ public class ConLLToNIF {
 		Individual sentenceResource = outputModel.createIndividual(uri, outputModel.createClass(NIFOntClasses.RFC5147String.getUri()));
 		sentenceResource.addOntClass(NIFOntClasses.Sentence.getOntClass(outputModel));
 		sentenceResource.addOntClass(NIFOntClasses.String.getOntClass(outputModel));
-		sentenceResource.addProperty(NIFDatatypeProperties.beginIndex.getDatatypeProperty(outputModel), startOffset+"");
-		sentenceResource.addProperty(NIFDatatypeProperties.endIndex.getDatatypeProperty(outputModel), endOffset+"");
+    RDFDatatype nonNegInt = NodeFactory.getType(XSD.nonNegativeInteger.getURI());
+    sentenceResource.addProperty(NIFDatatypeProperties.beginIndex.getDatatypeProperty(outputModel), startOffset+"", nonNegInt);
+		sentenceResource.addProperty(NIFDatatypeProperties.endIndex.getDatatypeProperty(outputModel), endOffset+"", nonNegInt);
 		sentenceResource.addLiteral(NIFDatatypeProperties.anchorOf.getDatatypeProperty(outputModel), outputModel.createLiteral(sentence));
 		return sentenceResource;
 	}


### PR DESCRIPTION
Text2RDF and ConLLToNIF produced nif:beginIndex and nif:endIndex assertions
with untyped literals, which does not fit the ontology and also created validation
errors when sending results from Text2RDF to RDFUnit.
