### PR TITLE
Update Repo URIs so the project compiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ log/
 tools/velocity.log
 tools/velocity.log.*
 java-maven/tools/velocity.log
+
+java-maven/.pom.xml.swp

--- a/java-maven/pom.xml
+++ b/java-maven/pom.xml
@@ -403,7 +403,7 @@
       <id>central</id>
       <name>Maven Repository Switchboard</name>
       <layout>default</layout>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -440,7 +440,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Maven Plugin Repository</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <layout>default</layout>
       <snapshots>
         <enabled>false</enabled>


### PR DESCRIPTION
There is a hard-coded URL in the POMs that doesn't work anymore and I have updated this so Maven still runs